### PR TITLE
Updates to be compatible with Rails 4.

### DIFF
--- a/pg-app-name.gemspec
+++ b/pg-app-name.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.name          = "pg-app-name"
   gem.require_paths = ["lib"]
   gem.version       = Pg::App::Name::VERSION
-  gem.add_dependency 'activerecord', '~> 3'
+  gem.add_dependency 'activerecord', '~> 4'
   gem.add_dependency 'pg', '~> 0'
   gem.add_development_dependency 'rake', '~> 0.9'
   gem.add_development_dependency 'rspec', '~> 2'

--- a/spec/pg-app-name_spec.rb
+++ b/spec/pg-app-name_spec.rb
@@ -10,7 +10,7 @@ describe "Set PG App Name" do
   end
 
   it "should monkey patch ConnectionPool" do
-    cp = ActiveRecord::ConnectionAdapters::ConnectionPool.new(ActiveRecord::Base::ConnectionSpecification.new(connection_params,"postgresql_connection"))
+    cp = ActiveRecord::ConnectionAdapters::ConnectionPool.new(ActiveRecord::ConnectionAdapters::ConnectionSpecification.new(connection_params,"postgresql_connection"))
     cp.respond_to?(:new_connection_with_application_name).should be_true
   end
 
@@ -23,7 +23,7 @@ describe "Set PG App Name" do
   end
 
   it "should set the application name while establishing connection with connection pool" do
-    cp = ActiveRecord::ConnectionAdapters::ConnectionPool.new(ActiveRecord::Base::ConnectionSpecification.new(connection_params,"postgresql_connection"))
+    cp = ActiveRecord::ConnectionAdapters::ConnectionPool.new(ActiveRecord::ConnectionAdapters::ConnectionSpecification.new(connection_params,"postgresql_connection"))
     conn = cp.checkout
     result = conn.exec_query "select application_name from pg_stat_activity where datname='"+connection_params[:database]+"'"
     result.rows.flatten!


### PR DESCRIPTION
- Updates the activerecord dependency
- Changes ActiveRecord::Base::ConnectionSpecification to ActiveRecord::ConnectionAdapters::ConnectionSpecification. This was changed in rails commit dae7b6545372cba40e08554b9a7b2f391eaa5c6e

I don't know how much you're interested in rails 4 compatibility, but it seems to be pretty straightforward-- this was all I had to do to get the tests passing.

Thank you for this gem!
